### PR TITLE
Ensure course exists before saving note

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,16 @@ io.on('connection', (socket) => {
   }
 
   socket.on('addNote', data => {
-    const note = { timestamp: new Date().toISOString(), code: data.code, note: data.note };
+    if (!currentCourse) {
+      socket.emit('error', 'No course loaded');
+      return;
+    }
+
+    const note = {
+      timestamp: new Date().toISOString(),
+      code: data.code,
+      note: data.note
+    };
     notes.push(note);
     saveNotes();
     io.emit('noteAdded', note);

--- a/public/script.js
+++ b/public/script.js
@@ -46,7 +46,11 @@ courseSelect.addEventListener('change', () => {
 });
 
 addNoteBtn.addEventListener('click', () => {
-  socket.emit('addNote', { code: codeInput.value, note: noteInput.value });
+  if (!currentCourse) return;
+  socket.emit('addNote', {
+    code: codeInput.value,
+    note: noteInput.value
+  });
   codeInput.value = '';
   noteInput.value = '';
 });
@@ -65,6 +69,10 @@ socket.on('courseLoaded', data => {
 
 socket.on('noteAdded', note => {
   renderNote(note);
+});
+
+socket.on('error', message => {
+  alert(message);
 });
 
 function renderNote(note) {


### PR DESCRIPTION
## Summary
- check server has a course selected when adding a note
- prevent adding notes on the client if no course is active
- show simple alert for server error events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687693877dec8321b8af4b52ebae016e