### PR TITLE
Enable live sync for code field

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple production note logging app with realtime sync.
 - Displays a timecode based on the system time.
 - Input fields for `Code` and `Production Notes`.
 - Notes are stored by course (project) and synced in realtime across clients.
+- The `Code` field syncs live across connected clients.
 - Export notes to CSV.
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ if (!fs.existsSync(COURSES_DIR)) {
 
 let currentCourse = null;
 let notes = [];
+let currentCodeText = '';
 
 function loadCourse(course) {
   const file = path.join(COURSES_DIR, course, 'notes.json');
@@ -117,6 +118,9 @@ io.on('connection', (socket) => {
     socket.emit('courseLoaded', { course: currentCourse, notes });
     log(`Sent courseLoaded to ${socket.id} for ${currentCourse}`);
   }
+  if (currentCodeText) {
+    socket.emit('codeUpdate', currentCodeText);
+  }
 
   socket.on('addNote', data => {
     if (!currentCourse) {
@@ -142,6 +146,12 @@ io.on('connection', (socket) => {
       socket.broadcast.emit('courseLoaded', { course, notes });
       log(`Socket ${socket.id} switched to course ${course}`);
     }
+  });
+
+  socket.on('codeUpdate', value => {
+    currentCodeText = value;
+    socket.broadcast.emit('codeUpdate', value);
+    log('codeUpdate', value);
   });
 
   socket.on('disconnect', () => {

--- a/public/script.js
+++ b/public/script.js
@@ -61,6 +61,12 @@ courseSelect.addEventListener('change', () => {
   fetch(`/courses/${course}/select`, { method: 'POST' }).then(() => { devLog(`Selected course ${course}`); });
 });
 
+codeInput.addEventListener('input', () => {
+  if (socket) {
+    socket.emit('codeUpdate', codeInput.value);
+  }
+});
+
 addNoteBtn.addEventListener('click', () => {
   if (!currentCourse) return;
   socket.emit('addNote', {
@@ -93,6 +99,9 @@ function initSocket(url) {
   socket.on('noteAdded', note => {
     renderNote(note);
     devLog('Note added');
+  });
+  socket.on('codeUpdate', value => {
+    codeInput.value = value;
   });
 }
 


### PR DESCRIPTION
## Summary
- sync live text from the `Code` field via Socket.IO
- listen for code input updates clientside
- document the new feature

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876b41a0d7c8321bb5a98e681807fd9