### PR TITLE
Revamp layout with date and expandable course creation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,18 +10,23 @@
   <div id="topBar">
     <div id="logo">
   <img src="/logos/leaderpass-studios-logo-white_small.png" alt="LeaderPass Studios Logo"></div>
-    <div id="timecode">00:00:00:00</div>
+    <div id="currentDate"></div>
   </div>
+
+  <div id="timecode">00:00:00:00</div>
 
   <div id="courseSelector">
     <label for="courseSelect">Course:</label>
     <select id="courseSelect"></select>
-    <input id="newCourse" placeholder="New Course" />
-    <button id="createCourse">Create</button>
+    <button id="showNewCourse">+</button>
+    <span id="newCourseContainer" style="display:none;">
+      <input id="newCourse" placeholder="New Course" />
+      <button id="createCourse">Create</button>
+    </span>
   </div>
 
   <div id="notePanel">
-    <input id="codeInput" placeholder="Code" />
+    <textarea id="codeInput" placeholder="Code"></textarea>
     <input id="noteInput" placeholder="Production Notes" />
     <button id="addNote">Add Note</button>
   </div>

--- a/public/script.js
+++ b/public/script.js
@@ -9,9 +9,18 @@ function updateTimecode() {
 }
 setInterval(updateTimecode, 40);
 
+function updateDate() {
+  const now = new Date();
+  const options = { weekday: 'long', month: 'long', day: 'numeric' };
+  document.getElementById('currentDate').innerText = now.toLocaleDateString(undefined, options);
+}
+updateDate();
+
 const courseSelect = document.getElementById('courseSelect');
 const newCourse = document.getElementById('newCourse');
 const createCourse = document.getElementById('createCourse');
+const showNewCourse = document.getElementById('showNewCourse');
+const newCourseContainer = document.getElementById('newCourseContainer');
 const codeInput = document.getElementById('codeInput');
 const noteInput = document.getElementById('noteInput');
 const addNoteBtn = document.getElementById('addNote');
@@ -49,11 +58,25 @@ function refreshCourseList() {
 }
 refreshCourseList();
 
+showNewCourse.addEventListener('click', () => {
+  if (newCourseContainer.style.display === 'none') {
+    newCourseContainer.style.display = 'inline';
+    newCourse.focus();
+  } else {
+    newCourseContainer.style.display = 'none';
+  }
+});
+
 createCourse.addEventListener('click', () => {
   const name = newCourse.value.trim();
   if (!name) return;
   fetch('/courses', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name }) })
-    .then(() => { newCourse.value = ''; refreshCourseList(); devLog(`Created course ${name}`); });
+    .then(() => {
+      newCourse.value = '';
+      newCourseContainer.style.display = 'none';
+      refreshCourseList();
+      devLog(`Created course ${name}`);
+    });
 });
 
 courseSelect.addEventListener('change', () => {

--- a/public/style.css
+++ b/public/style.css
@@ -52,23 +52,40 @@ body {
   height: auto;
 }
 
+#currentDate {
+  font-size: 24px;
+}
+
 #timecode {
   font-size: 48px;
   font-family: 'Courier New', monospace;
+  text-align: center;
+  margin-top: 10px;
 }
 
 #courseSelector {
   margin: 20px;
 }
 
+#newCourseContainer {
+  margin-left: 10px;
+}
+
 #notePanel {
   display: flex;
+  flex-direction: column;
   gap: 20px;
   padding: 20px;
 }
 
+#notePanel textarea,
 #notePanel input {
-  flex: 1;
+  width: 100%;
+}
+
+#codeInput {
+  height: 100px;
+  resize: vertical;
 }
 
 button, input, select {


### PR DESCRIPTION
## Summary
- show current date in the top bar
- move timecode below the top bar
- hide new course controls until the + button is clicked
- make code input a larger textarea above notes

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877af86d0ac8321915288ee46afea74