### PR TITLE
Add note editing and course management

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,8 @@
     <select id="courseSelect"></select>
     <input id="newCourse" placeholder="New Course" />
     <button id="createCourse">Create</button>
+    <button id="renameCourse">Rename</button>
+    <button id="deleteCourse">Delete</button>
   </div>
 
   <div id="notePanel">

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,6 @@
 let socket;
 let currentCourse = null;
+let notesArr = [];
 
 function updateTimecode() {
   const now = new Date();
@@ -12,6 +13,8 @@ setInterval(updateTimecode, 40);
 const courseSelect = document.getElementById('courseSelect');
 const newCourse = document.getElementById('newCourse');
 const createCourse = document.getElementById('createCourse');
+const renameCourseBtn = document.getElementById('renameCourse');
+const deleteCourseBtn = document.getElementById('deleteCourse');
 const codeInput = document.getElementById('codeInput');
 const noteInput = document.getElementById('noteInput');
 const addNoteBtn = document.getElementById('addNote');
@@ -56,6 +59,24 @@ createCourse.addEventListener('click', () => {
     .then(() => { newCourse.value = ''; refreshCourseList(); devLog(`Created course ${name}`); });
 });
 
+renameCourseBtn.addEventListener('click', () => {
+  if (!currentCourse) return;
+  const newName = prompt('Enter new course name', currentCourse);
+  if (!newName) return;
+  fetch(`/courses/${currentCourse}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: newName })
+  }).then(() => { refreshCourseList(); devLog(`Renamed course to ${newName}`); });
+});
+
+deleteCourseBtn.addEventListener('click', () => {
+  if (!currentCourse) return;
+  if (!confirm(`Delete course ${currentCourse}?`)) return;
+  fetch(`/courses/${currentCourse}`, { method: 'DELETE' })
+    .then(() => { currentCourse = null; notesArr = []; renderNotes(); refreshCourseList(); devLog('Course deleted'); });
+});
+
 courseSelect.addEventListener('change', () => {
   const course = courseSelect.value;
   fetch(`/courses/${course}/select`, { method: 'POST' }).then(() => { devLog(`Selected course ${course}`); });
@@ -91,14 +112,25 @@ function initSocket(url) {
   socket.on('connect', () => devLog('Connected to server'));
   socket.on('courseLoaded', data => {
     currentCourse = data.course;
-    notesLog.innerHTML = '';
-    data.notes.forEach(renderNote);
+    notesArr = data.notes;
+    renderNotes();
     refreshCourseList();
     devLog(`Course loaded ${data.course}`);
   });
   socket.on('noteAdded', note => {
-    renderNote(note);
+    notesArr.push(note);
+    renderNotes();
     devLog('Note added');
+  });
+  socket.on('noteEdited', data => {
+    notesArr[data.index] = data.note;
+    renderNotes();
+    devLog('Note edited');
+  });
+  socket.on('noteDeleted', index => {
+    notesArr.splice(index, 1);
+    renderNotes();
+    devLog('Note deleted');
   });
   socket.on('codeUpdate', value => {
     codeInput.value = value;
@@ -109,9 +141,15 @@ socket.on('error', message => {
   alert(message);
 });
 
-function renderNote(note) {
+function renderNotes() {
+  notesLog.innerHTML = '';
+  notesArr.forEach((n, i) => renderNote(n, i));
+}
+
+function renderNote(note, index) {
   const div = document.createElement('div');
   div.className = 'noteItem';
+  div.dataset.index = index;
 
   const ts = document.createElement('span');
   ts.className = 'timestamp';
@@ -120,8 +158,33 @@ function renderNote(note) {
   const text = document.createElement('span');
   text.textContent = ` ${note.code} - ${note.note}`;
 
+  const actions = document.createElement('span');
+  actions.className = 'noteActions';
+  const editBtn = document.createElement('span');
+  editBtn.textContent = '✏️';
+  editBtn.style.cursor = 'pointer';
+  editBtn.addEventListener('click', () => {
+    const newCode = prompt('Edit code', note.code);
+    if (newCode === null) return;
+    const newNote = prompt('Edit note', note.note);
+    if (newNote === null) return;
+    socket.emit('editNote', { index, code: newCode, note: newNote });
+  });
+  const delBtn = document.createElement('span');
+  delBtn.textContent = '🗑️';
+  delBtn.style.cursor = 'pointer';
+  delBtn.style.marginLeft = '10px';
+  delBtn.addEventListener('click', () => {
+    if (confirm('Delete this note?')) {
+      socket.emit('deleteNote', index);
+    }
+  });
+  actions.appendChild(editBtn);
+  actions.appendChild(delBtn);
+
   div.appendChild(ts);
   div.appendChild(text);
+  div.appendChild(actions);
   notesLog.appendChild(div);
   notesLog.scrollTop = notesLog.scrollHeight;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -101,6 +101,13 @@ input:focus, select:focus {
 .noteItem {
   border-bottom: 1px solid #444;
   padding: 4px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.noteActions span {
+  margin-left: 5px;
 }
 
 .noteItem .timestamp {


### PR DESCRIPTION
## Summary
- enable editing and deletion of notes via socket events
- allow courses to be renamed or deleted on the server
- add UI buttons for renaming and deleting courses
- implement edit/delete icons on notes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877b06b00288321854132b3f52f94f7