### PR TITLE
Update layout for code & notes fields

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,8 +30,10 @@
   </div>
 
   <div id="notePanel">
-    <textarea id="codeInput" placeholder="Code"></textarea>
-    <input id="noteInput" placeholder="Production Notes" />
+    <div id="noteInputs">
+      <textarea id="codeInput" placeholder="Code"></textarea>
+      <input id="noteInput" placeholder="Production Notes" />
+    </div>
     <button id="addNote">Add Note</button>
   </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -78,14 +78,27 @@ body {
   padding: 20px;
 }
 
-#notePanel input,
-#notePanel textarea {
+#noteInputs {
+  display: flex;
+  gap: 20px;
+  width: 100%;
+  align-items: stretch;
+}
+
+#noteInputs textarea,
+#noteInputs input {
   width: 100%;
 }
 
 #codeInput {
-  height: 200px;
+  flex: 1;
+  aspect-ratio: 1 / 1;
   font-size: 24px;
+}
+
+#noteInput {
+  flex: 4;
+  height: 100%;
 }
 
 #codeInput::placeholder {


### PR DESCRIPTION
## Summary
- align code and production note fields horizontally
- make code field square and have notes field match its height
- keep responsive ratio of 1:4 for code to notes width

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877c85ce6908321bbe91e9ac0adf936