### PR TITLE
Use bold Metropolis font for time display

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -10,6 +10,12 @@
   font-weight: normal;
   font-style: normal;
 }
+@font-face {
+  font-family: 'Metropolis';
+  src: url('fonts/Metropolis-Bold.otf') format('opentype');
+  font-weight: bold;
+  font-style: normal;
+}
 
 body {
   background-color: var(--background);
@@ -54,12 +60,14 @@ body {
 
 #currentDate {
   font-size: 48px;
-  font-family: 'Courier New', monospace;
+  font-family: 'Metropolis', Arial, sans-serif;
+  font-weight: bold;
 }
 
 #timecode {
   font-size: 72px;
-  font-family: 'Courier New', monospace;
+  font-family: 'Metropolis', Arial, sans-serif;
+  font-weight: bold;
 }
 
 #timecodeContainer {


### PR DESCRIPTION
## Summary
- load Metropolis-Bold.otf via @font-face
- style the date and timecode with Metropolis bold

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877c88718dc83218227357e12cbc050