### PR TITLE
Add noActiveCourse state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ app.delete('/courses/:course', (req, res) => {
   if (currentCourse === course) {
     currentCourse = null;
     notes = [];
+    io.emit('noActiveCourse');
   }
   io.emit('courseDeleted', course);
   log(`Deleted course ${course}`);
@@ -147,6 +148,8 @@ io.on('connection', (socket) => {
   if (currentCourse) {
     socket.emit('courseLoaded', { course: currentCourse, notes });
     log(`Sent courseLoaded to ${socket.id} for ${currentCourse}`);
+  } else {
+    socket.emit('noActiveCourse');
   }
   if (currentCodeText) {
     socket.emit('codeUpdate', currentCodeText);


### PR DESCRIPTION
## Summary
- introduce frontend helpers to switch to an inactive state
- disable input fields when no course is active
- notify clients when the active course is removed
- add `.gitignore` for `node_modules`

## Testing
- `npm install`
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_6877cdb5cc6483219a43368770490bfa