### PR TITLE
Move Add Note button into input and adjust log alignment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,9 +33,11 @@
   <div id="notePanel">
     <div id="noteInputs">
       <textarea id="codeInput" placeholder="Code"></textarea>
-      <input id="noteInput" placeholder="Production Notes" />
+      <div id="noteInputWrapper">
+        <input id="noteInput" placeholder="Production Notes" />
+        <button id="addNote">Send</button>
+      </div>
     </div>
-    <button id="addNote">Add Note</button>
   </div>
 
   <div id="notesLog"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -293,6 +293,7 @@ function renderNote(note, index) {
   ts.textContent = `[${note.timestamp}]`;
 
   const text = document.createElement('span');
+  text.className = 'noteText';
   text.textContent = ` ${note.code} - ${note.note}`;
 
   const actions = document.createElement('span');

--- a/public/style.css
+++ b/public/style.css
@@ -105,6 +105,22 @@ body {
   width: 100%;
 }
 
+#noteInputWrapper {
+  position: relative;
+  flex: 4;
+}
+
+#noteInputWrapper input {
+  width: 100%;
+  padding-right: 80px;
+}
+
+#addNote {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+}
+
 #codeInput {
   flex: 1;
   aspect-ratio: 1 / 1;
@@ -112,7 +128,6 @@ body {
 }
 
 #noteInput {
-  flex: 4;
   height: 100%;
 }
 
@@ -149,9 +164,14 @@ input:focus, select:focus, textarea:focus {
 .noteItem {
   border-bottom: 1px solid #444;
   padding: 4px 0;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  column-gap: 10px;
+}
+
+.noteText {
+  text-align: left;
 }
 
 .noteActions span {


### PR DESCRIPTION
## Summary
- embed Add Note button inside the Production Notes input
- style button to appear at the bottom-right of the input
- left-align log entries with new CSS

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877dfa520808321ba995de33aeb1853