### PR TITLE
Add responsive scaling with minimum size

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div id="appWrapper">
   <div class="app-container">
   <div id="topBar">
     <div id="logo">
@@ -94,6 +95,7 @@
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="script.js"></script>
+  </div>
   </div>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -323,3 +323,14 @@ function renderNote(note, index) {
   notesLog.appendChild(div);
   notesLog.scrollTop = notesLog.scrollHeight;
 }
+
+// Scale the app based on window size with a minimum scale
+function updateScale() {
+  const baseWidth = 1200; // should match .app-container width in CSS
+  const minScale = 0.5; // don't scale below half size
+  const scale = Math.max(minScale, Math.min(1, window.innerWidth / baseWidth));
+  document.documentElement.style.setProperty('--scale', scale);
+}
+
+window.addEventListener('resize', updateScale);
+updateScale();

--- a/public/style.css
+++ b/public/style.css
@@ -2,6 +2,7 @@
   --background: #000000;
   --text: #ffffff;
   --accent: #FFD700;
+  --scale: 1; /* default scale factor */
 }
 
 @font-face {
@@ -26,10 +27,17 @@ body {
 }
 
 .app-container {
-  max-width: 1200px; /* or whatever feels good for your layout */
+  width: 100%;
   margin: 0 auto;
-  padding: 2rem; /* optional: adds breathing room */
+  padding: 2rem; /* adds breathing room */
   box-sizing: border-box;
+}
+
+#appWrapper {
+  width: 1200px; /* base layout width */
+  margin: 0 auto;
+  transform-origin: top left;
+  transform: scale(var(--scale));
 }
 
 .stacked-container {


### PR DESCRIPTION
## Summary
- allow UI to scale down instead of overflowing
- wrap app content in an element that can be scaled
- compute scale based on window width in JS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877e9ace2648321ad9d362247ccfbab