### PR TITLE
Fix socket error handler placement

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -241,6 +241,9 @@ exportCsv.addEventListener('click', () => {
 
 function initSocket(url) {
   socket = io(url);
+  socket.on('error', message => {
+    showAlert(message);
+  });
   devLog(`Connecting to ${url}`);
   socket.on('log', devLog);
   socket.on('connect', () => devLog('Connected to server'));
@@ -273,10 +276,6 @@ function initSocket(url) {
     codeInput.value = value;
   });
 }
-
-socket.on('error', message => {
-  showAlert(message);
-});
 
 function renderNotes() {
   notesLog.innerHTML = '';


### PR DESCRIPTION
## Summary
- initialize socket error handler only after connecting
- avoid referencing `socket` before it is set

## Testing
- `node index.js` (server startup)
- `node test_socket.js` with jsdom to ensure page load without errors

------
https://chatgpt.com/codex/tasks/task_e_687804a749e88321947cbbcf625327b6