### PR TITLE
Add batch note deletion feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,6 +189,25 @@ io.on('connection', (socket) => {
     log(`Deleted note ${index} from ${currentCourse}`);
   });
 
+  socket.on('deleteNotes', indices => {
+    if (!Array.isArray(indices)) return;
+    const unique = [...new Set(indices.filter(i => typeof i === 'number' && notes[i]))]
+      .sort((a, b) => b - a);
+    if (unique.length === 0) return;
+    const removed = [];
+    for (const idx of unique) {
+      if (notes[idx]) {
+        notes.splice(idx, 1);
+        removed.push(idx);
+      }
+    }
+    if (removed.length > 0) {
+      saveNotes();
+      io.emit('notesDeleted', removed);
+      log(`Deleted notes ${removed.join(',')} from ${currentCourse}`);
+    }
+  });
+
   socket.on('loadCourse', course => {
     if (fs.existsSync(path.join(COURSES_DIR, course))) {
       loadCourse(course);

--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,11 @@
 
   <div id="notesLog"></div>
 
+  <div id="batchControls" class="hidden">
+    <button id="deleteSelected">Delete Selected</button>
+    <button id="deselectAll">Deselect All</button>
+  </div>
+
   <div id="bottomBar">
     <button id="exportCsv">Export CSV</button>
     <div>IP: <span id="ipAddress">...</span></div>

--- a/public/script.js
+++ b/public/script.js
@@ -51,6 +51,12 @@ const editCancel = document.getElementById('editCancel');
 const alertModal = document.getElementById('alertModal');
 const alertMessage = document.getElementById('alertMessage');
 const alertOk = document.getElementById('alertOk');
+const batchControls = document.getElementById('batchControls');
+const deleteSelectedBtn = document.getElementById('deleteSelected');
+const deselectAllBtn = document.getElementById('deselectAll');
+
+let batchMode = false;
+const selected = new Set();
 
 function setNoActiveCourse() {
   currentCourse = null;
@@ -108,6 +114,20 @@ function showConfirm(message, onOk) {
   showModal(confirmModal);
   confirmOk.onclick = () => { hideModal(confirmModal); onOk(); };
   confirmCancel.onclick = () => hideModal(confirmModal);
+}
+
+function exitBatchMode() {
+  batchMode = false;
+  selected.clear();
+  batchControls.classList.add('hidden');
+  document.querySelectorAll('.noteActions').forEach(a => a.classList.remove('hidden'));
+  document.querySelectorAll('.noteItem').forEach(n => n.classList.remove('selected'));
+}
+
+function enterBatchMode() {
+  batchMode = true;
+  batchControls.classList.remove('hidden');
+  document.querySelectorAll('.noteActions').forEach(a => a.classList.add('hidden'));
 }
 
 let editIndex = null;
@@ -239,6 +259,17 @@ exportCsv.addEventListener('click', () => {
   devLog(`Export CSV for ${currentCourse}`);
 });
 
+deleteSelectedBtn.addEventListener('click', () => {
+  if (selected.size === 0) return;
+  const indices = Array.from(selected).sort((a,b) => a - b);
+  socket.emit('deleteNotes', indices);
+  exitBatchMode();
+});
+
+deselectAllBtn.addEventListener('click', () => {
+  exitBatchMode();
+});
+
 function initSocket(url) {
   socket = io(url);
   devLog(`Connecting to ${url}`);
@@ -269,6 +300,11 @@ function initSocket(url) {
     renderNotes();
     devLog('Note deleted');
   });
+  socket.on('notesDeleted', indices => {
+    indices.sort((a,b) => b - a).forEach(i => notesArr.splice(i,1));
+    renderNotes();
+    devLog('Notes deleted');
+  });
   socket.on('codeUpdate', value => {
     codeInput.value = value;
   });
@@ -287,6 +323,9 @@ function renderNote(note, index) {
   const div = document.createElement('div');
   div.className = 'noteItem';
   div.dataset.index = index;
+  if (selected.has(index)) {
+    div.classList.add('selected');
+  }
 
   const ts = document.createElement('span');
   ts.className = 'timestamp';
@@ -322,4 +361,23 @@ function renderNote(note, index) {
   div.appendChild(actions);
   notesLog.appendChild(div);
   notesLog.scrollTop = notesLog.scrollHeight;
+
+  if (batchMode) {
+    actions.classList.add('hidden');
+  }
+
+  div.addEventListener('click', (e) => {
+    if (e.shiftKey && !batchMode) {
+      enterBatchMode();
+    }
+    if (batchMode) {
+      if (selected.has(index)) {
+        selected.delete(index);
+        div.classList.remove('selected');
+      } else {
+        selected.add(index);
+        div.classList.add('selected');
+      }
+    }
+  });
 }

--- a/public/style.css
+++ b/public/style.css
@@ -289,3 +289,11 @@ textarea:disabled {
   cursor: not-allowed;
 }
 
+.noteItem.selected {
+  background-color: #333;
+}
+
+#batchControls {
+  margin: 1rem 0;
+}
+


### PR DESCRIPTION
## Summary
- enable batch selection of notes on the client
- render selection state and batch action controls
- implement `deleteNotes` socket event on the server
- style selected notes and batch controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687804b0e1208321a2926f5d3c671f73