### PR TITLE
Fix placeholder text size for note input

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -188,6 +188,7 @@ body {
 }
 
 #noteInput::placeholder {
+  font-size: 1.5rem;
   vertical-align: top;
   text-align: left;
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- match the font size of the `noteInput` placeholder to the `codeInput` placeholder for consistency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687807086cc08321aacd0598c51667cc