### PR TITLE
Add batch note deletion feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,6 +189,25 @@ io.on('connection', (socket) => {
     log(`Deleted note ${index} from ${currentCourse}`);
   });
 
+  socket.on('deleteNotes', indices => {
+    if (!Array.isArray(indices)) return;
+    const unique = [...new Set(indices.filter(i => typeof i === 'number' && notes[i]))]
+      .sort((a, b) => b - a);
+    if (unique.length === 0) return;
+    const removed = [];
+    for (const idx of unique) {
+      if (notes[idx]) {
+        notes.splice(idx, 1);
+        removed.push(idx);
+      }
+    }
+    if (removed.length > 0) {
+      saveNotes();
+      io.emit('notesDeleted', removed);
+      log(`Deleted notes ${removed.join(',')} from ${currentCourse}`);
+    }
+  });
+
   socket.on('loadCourse', course => {
     if (fs.existsSync(path.join(COURSES_DIR, course))) {
       loadCourse(course);

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,11 @@
     </div>
   </div>
 
+  <div id="batchControls" class="hidden">
+    <button id="deleteSelected">Delete Selected</button>
+    <button id="deselectAll">Deselect All</button>
+  </div>
+
   <div id="notesLog"></div>
 
   <div id="bottomBar">

--- a/public/style.css
+++ b/public/style.css
@@ -188,9 +188,22 @@ input:focus, select:focus, textarea:focus {
   border-bottom: 1px solid #444;
   padding: 0.25rem 0;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
   column-gap: 0.625rem;
+  cursor: pointer;
+}
+
+.noteItem:hover:not(.selected) {
+  background-color: #222;
+}
+
+.selectBox {
+  margin-left: 0.5rem;
+}
+
+.selectBox.hidden {
+  display: none;
 }
 
 .noteText {
@@ -287,5 +300,13 @@ textarea:disabled {
   color: #777;
   border-color: #444;
   cursor: not-allowed;
+}
+
+.noteItem.selected {
+  background-color: #333;
+}
+
+#batchControls {
+  margin: 1rem 1.25rem;
 }
 


### PR DESCRIPTION
## Summary
- enable batch selection of notes on the client
- render selection state and batch action controls
- implement `deleteNotes` socket event on the server
- style selected notes and batch controls
- allow clicking a note to edit it and highlight on hover
- fix socket error listener initialization
- tweak batch selection UI to use Ctrl/Cmd key, show checkboxes, and auto-exit when deselected

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687804b0e1208321a2926f5d3c671f73