### PR TITLE
Update note input behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple production note logging app with realtime sync.
 - Input fields for `Code` and `Production Notes`.
 - Notes are stored by course (project) and synced in realtime across clients.
 - The `Code` field syncs live across connected clients.
+- Press Enter in the Production Notes field or click Send to add a note.
 - Export notes to CSV.
 
 ## Usage

--- a/public/script.js
+++ b/public/script.js
@@ -264,15 +264,23 @@ codeInput.addEventListener('input', () => {
   }
 });
 
-addNoteBtn.addEventListener('click', () => {
+function sendNote() {
   if (!currentCourse) return;
   socket.emit('addNote', {
     code: codeInput.value,
     note: noteInput.value
   });
-  codeInput.value = '';
   noteInput.value = '';
   devLog('Sent addNote');
+}
+
+addNoteBtn.addEventListener('click', sendNote);
+
+noteInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    sendNote();
+  }
 });
 
 exportCsv.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- keep code text after sending notes
- allow pressing Enter to send notes
- document Enter key in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878104881008321b3a0164c789dcf7a