### PR TITLE
Use writable courses directory when packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,16 @@ npm install
 node index.js
 ```
 
+### Configuration
+
+The application stores notes in a `courses` directory. When running a packaged
+binary (e.g. using `pkg`), `__dirname` is read-only, so the location of this
+directory defaults to a `courses` folder next to the executable. You can
+override the path by setting the `COURSES_DIR` environment variable:
+
+```bash
+COURSES_DIR=/some/writable/path node index.js
+```
+
 Open `http://localhost:4000` in your browser. The server logs its URL on
 startup so you can access it from other machines on the same network.

--- a/index.js
+++ b/index.js
@@ -40,7 +40,11 @@ app.get('/ip', (req, res) => {
   res.json({ ip: getHostIp() });
 });
 
-const COURSES_DIR = path.join(__dirname, 'courses');
+// The courses directory stores user generated files. When packaged with `pkg`,
+// `__dirname` is read-only so we need a writable location. Default to a
+// "courses" folder next to the executable (process.cwd()), but allow overriding
+// via the COURSES_DIR environment variable.
+const COURSES_DIR = process.env.COURSES_DIR || path.join(process.cwd(), 'courses');
 if (!fs.existsSync(COURSES_DIR)) {
   fs.mkdirSync(COURSES_DIR);
 }


### PR DESCRIPTION
## Summary
- point courses directory to a writable location when running as a packaged binary
- document the `COURSES_DIR` environment variable

## Testing
- `npm install`
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68793e445dec8321a0e54171fae53086