### PR TITLE
Add notes log visibility toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,8 @@
     <button id="deselectAll">Deselect All</button>
   </div>
 
+  <button id="toggleNotesLog">Hide Log</button>
+
   <div id="notesLog"></div>
 
   <div id="bottomBar">

--- a/public/script.js
+++ b/public/script.js
@@ -33,6 +33,7 @@ const codeInput = document.getElementById('codeInput');
 const noteInput = document.getElementById('noteInput');
 const addNoteBtn = document.getElementById('addNote');
 const notesLog = document.getElementById('notesLog');
+const toggleNotesLog = document.getElementById('toggleNotesLog');
 const exportCsv = document.getElementById('exportCsv');
 const ipAddress = document.getElementById('ipAddress');
 const devConsole = document.getElementById('devConsole');
@@ -89,6 +90,11 @@ setNoActiveCourse();
 
 toggleDevConsole.addEventListener('click', () => {
   devConsole.classList.toggle('show');
+});
+
+toggleNotesLog.addEventListener('click', () => {
+  notesLog.classList.toggle('hidden');
+  toggleNotesLog.textContent = notesLog.classList.contains('hidden') ? 'Show Log' : 'Hide Log';
 });
 
 courseMenuToggle.addEventListener('click', (e) => {

--- a/public/style.css
+++ b/public/style.css
@@ -215,6 +215,10 @@ input:focus, select:focus, textarea:focus {
   border-color: var(--accent);
 }
 
+#toggleNotesLog {
+  margin: 0 1.25rem 0.5rem;
+}
+
 #notesLog {
   max-height: 18.75rem;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add **Hide Log** button above notes log
- implement JS to toggle log visibility
- style toggle button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68794f38def08321a57498e0b95b39b0