### PR TITLE
Add handshake to request active course

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -199,6 +199,9 @@ function refreshCourseList() {
     }
     if (data.current) {
       courseSelect.value = data.current;
+      if (socket && socket.connected && currentCourse !== data.current) {
+        socket.emit('loadCourse', data.current);
+      }
     } else {
       courseSelect.value = '';
       setNoActiveCourse();
@@ -313,7 +316,10 @@ function initSocket(url) {
   });
   devLog(`Connecting to ${url}`);
   socket.on('log', devLog);
-  socket.on('connect', () => devLog('Connected to server'));
+  socket.on('connect', () => {
+    devLog('Connected to server');
+    refreshCourseList();
+  });
   socket.on('courseLoaded', data => {
     setActiveCourse(data.course, data.notes);
     refreshCourseList();


### PR DESCRIPTION
## Summary
- refresh course list triggers a `loadCourse` request if the socket is connected and the client hasn't loaded the current course
- reconnecting now refreshes the course list so new clients request the active course

## Testing
- `npm --check public/script.js`
- `npm --check index.js`
- `npm start` *(fails: Can't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_687a71a238308321b3ce904b082ece74